### PR TITLE
Docs :bulb: Documentação do repositório (CLAUDE.md, README, CONTRIBUTING, PR template)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Descrição
+
+<!-- O que essa PR faz e por quê. -->
+
+## Issue relacionada
+
+Closes #
+
+## Tipo de alteração
+
+- [ ] :bug: Fix
+- [ ] :sparkles: Feat
+- [ ] :ambulance: Hotfix
+- [ ] :recycle: Refactor
+- [ ] :test_tube: Test
+- [ ] :zap: Perf
+- [ ] :art: Style
+- [ ] :bulb: Docs
+- [ ] :rocket: Build
+- [ ] :see_no_evil: Chore
+- [ ] :rewind: Revert
+
+## Checklist
+
+- [ ] Reviewers atribuídos
+- [ ] Assignees atribuídos
+- [ ] Labels atribuídas
+- [ ] `npm run lint` e `npm run build` passam localmente
+
+## Como testar
+
+<!-- Passos para validar a alteração. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+Este arquivo fornece orientações ao Claude Code (claude.ai/code) para trabalhar com o código deste repositório.
+
+## Visão geral do projeto
+
+Este é um boilerplate/template para APIs Express + TypeScript. Os arquivos com prefixo `__test__` (`__test__.controller.ts`, `__test__.routes.ts`, `__test__.service.ts`) não são testes de fato — são um módulo de referência/scaffold que demonstra o padrão Controller → Service → Route que novas features devem copiar. Não há framework de testes configurado neste repositório (sem jest/mocha/vitest), apesar do nome `__test__`.
+
+## Comandos
+
+- `npm run dev` — roda o servidor de desenvolvimento com nodemon + ts-node, observando `src/**/*.ts` (hot reload, sem etapa de build).
+- `npm run build` — checa tipos e compila `src` para `out/` via `tsc`.
+- `npm start` — executa `prestart` (build) e depois `node out/src/index.js`. Use isso para rodar o build de produção compilado.
+- `npm run lint` — roda o ESLint no projeto.
+- `npm run create-image` — builda a imagem Docker (`docker build -t image .`).
+- `npm run create-container` — roda o container Docker, mapeando a porta 3001 do host para a porta 3000 do container.
+
+Atualmente não há suíte/runner de testes neste projeto.
+
+## Arquitetura
+
+Estrutura em camadas por recurso, conectadas em `src/app.ts`:
+
+- **Routes** (`src/routes/*.routes.ts`) — uma classe que encapsula um `Router` do Express. O construtor registra todos os bindings de verbos HTTP com os métodos do controller (usando `.bind()`, já que os métodos do controller são usados como callbacks independentes). Expõe `getRouter()`. O módulo exporta o router de uma instância singleton, não a classe.
+- **Controllers** (`src/controllers/*.controller.ts`) — uma classe que instancia seu respectivo service no construtor. Cada método é um handler assíncrono do Express: extrai `req.params`/`req.query`/`req.body`, faz validações mínimas (ex.: checagem de body obrigatório), delega ao service e envolve tudo em um try/catch que loga o erro e retorna `res.sendStatus(500)` em caso de falha.
+- **Services** (`src/services/*.service.ts`) — uma classe simples contendo a lógica de negócio, atualmente retornando dados mock/echo no template. É aqui que entraria a persistência/lógica de negócio real.
+- O registro de rotas de um recurso acontece em `src/app.ts` via `app.use("/api/<recurso>", <recurso>Routes)`. Um catch-all `app.use("/", ...)` no final retorna 404 para qualquer coisa não mapeada — novos routers de recursos precisam ser registrados antes dessa linha.
+
+Para adicionar um novo recurso, copie o trio controller/route/service `__test__`, renomeie e registre o novo router em `src/app.ts`.
+
+### Middleware de log de requisições
+
+`src/middleware/requestLogger.middleware.ts` roda em toda requisição. No evento `finish` da resposta, ele acrescenta uma linha JSON (data, método, url, status, duração) a um arquivo local `request.log`, usando os helpers `readFile`/`createFile` em `src/utils/`. É uma escrita de arquivo fire-and-forget, não um serviço de log externo.
+
+### Ambiente / deploy
+
+- O `.env` é carregado via `dotenv` em `src/app.ts`; existe um `.env.example` como template. O `src/index.ts` atualmente fixa a porta em `3000` em vez de lê-la do ambiente.
+- O `vercel.json` builda `src/index.ts` diretamente com `@vercel/node` e roteia todos os caminhos para ele — isso ignora o build `npm run build`/pasta `out` usado pelo Docker/`npm start`.
+- O `Dockerfile` é um build em dois estágios: compila com `tsc` em um estágio builder, depois copia `out/` e `.env` para um estágio de produção mais leve. Se um projeto não tiver `.env`, remova a linha `COPY .env ./` (observação já indicada inline no Dockerfile).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contribuindo
+
+Este documento define o padrão de branches, commits e Pull Requests deste repositório, adaptado para um repositório único, sem board de tarefas — issues do GitHub substituem o número de tarefa.
+
+## Tipos de alteração
+
+| Tipo         |      Ícone       | Código do ícone  | Descrição                                                                     |
+| ------------ | :--------------: | ---------------- | ------------------------------------------------------------------------------ |
+| Fix          |      :bug:       | bug              | Correção de bugs.                                                             |
+| Feat         |    :sparkles:    | sparkles         | Desenvolvimento de novas funcionalidades (features).                          |
+| Hotfix       |   :ambulance:    | ambulance        | Correção de bugs a partir da branch de produção (main).                       |
+| Refactor     |    :recycle:     | recycle          | Melhorias no código (ex.: reestruturações; melhorias no código).              |
+| Test         |   :test_tube:    | test_tube        | Criação ou alteração de arquivos de teste.                                    |
+| Perf         |      :zap:       | zap              | Mudanças a fim de melhorar a performance.                                     |
+| Style        |      :art:       | art              | Mudanças apenas em estilo de código (ex.: formatação; clean code).            |
+| Docs         |      :bulb:      | bulb             | Mudanças relacionadas à documentação.                                        |
+| Build        |     :rocket:     | rocket           | Mudanças em arquivos de build (ex.: Docker; `package.json`).                  |
+| Chore        |  :see_no_evil:   | see_no_evil      | Mudanças sem impacto direto na aplicação (ex.: alterações no `.gitignore`).   |
+| Revert       |     :rewind:     | rewind           | Reverter algum commit.                                                        |
+
+## Padrão de branches
+
+```
+<tipo>/<número-da-issue>-<descrição-curta(opcional)>
+```
+
+Exemplo:
+
+```
+fix/17-request-logger-appendfile
+```
+
+Sem issue aberta, o número pode ser omitido:
+
+```
+chore/update-gitignore
+```
+
+## Padrão de commits
+
+```
+<Tipo> <ícone> [#<número-da-issue>] <descrição-da-alteração>
+```
+
+Exemplo:
+
+```
+Fix :bug: [#17] Troca readFile+createFile por appendFile no logger
+```
+
+Sem issue relacionada, omita o `[#...]`:
+
+```
+Chore :see_no_evil: Atualiza .gitignore
+```
+
+## Pull Requests
+
+- Toda alteração passa por PR para a `main` — sem push direto.
+- Ao abrir o PR, preencha: **reviewers**, **assignees** e **labels** (use as labels já existentes no repositório: `bug`, `enhancement`, `documentation`, etc.).
+- Referencie a issue relacionada na descrição (ex.: `Closes #17`) para que ela seja fechada automaticamente no merge.
+- O título do PR segue o mesmo padrão do commit principal (`<Tipo> <ícone> [#<número>] <descrição>`).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# Novo rojeto
+# Template Express + TypeScript
+
+Boilerplate/template para APIs REST com Express e TypeScript, seguindo o padrão Controller → Service → Route por recurso.
+
+## Estrutura
+
+```
+src/
+├── app.ts                      # instância do Express, middlewares e registro de rotas
+├── index.ts                    # ponto de entrada, sobe o servidor na porta 3000
+├── controllers/                # camada de controllers (parseia request, delega ao service)
+├── routes/                     # camada de rotas (Router do Express por recurso)
+├── services/                   # camada de regra de negócio
+├── middleware/                 # middlewares do Express (ex.: log de requisições)
+└── utils/                      # funções auxiliares (leitura/escrita de arquivo, etc.)
+```
+
+O módulo `__test__` (`__test__.controller.ts`, `__test__.routes.ts`, `__test__.service.ts`) não é uma suíte de testes — é um scaffold de referência que demonstra o padrão a ser seguido para novos recursos. Não há framework de testes configurado neste projeto.
+
+## Como criar um novo recurso
+
+1. Copie o trio `__test__.controller.ts`, `__test__.routes.ts` e `__test__.service.ts`.
+2. Renomeie os arquivos e as classes para o novo recurso.
+3. Implemente a lógica de negócio real no service.
+4. Registre o novo router em `src/app.ts`, acima do catch-all `app.use("/", ...)`:
+   ```ts
+   app.use("/api/<recurso>", <recurso>Routes)
+   ```
+
+## Comandos
+
+| Comando | Descrição |
+| --- | --- |
+| `npm run dev` | Sobe o servidor de desenvolvimento com nodemon + ts-node, com hot reload (`src/**/*.ts`) |
+| `npm run build` | Faz a checagem de tipos e compila `src` para `out/` |
+| `npm start` | Builda (via `prestart`) e roda o build de produção compilado |
+| `npm run lint` | Roda o ESLint no projeto |
+| `npm run create-image` | Builda a imagem Docker (`docker build -t image .`) |
+| `npm run create-container` | Roda o container Docker, mapeando a porta 3001 do host para a 3000 do container |
+
+## Variáveis de ambiente
+
+O `.env` é carregado via `dotenv`. Use o `.env.example` como referência para criar o seu.
+
+## Deploy
+
+- **Docker**: build em dois estágios — compila com `tsc` e depois copia `out/` e `.env` para uma imagem de produção mais leve (veja o `Dockerfile`).
+- **Vercel**: o `vercel.json` builda `src/index.ts` diretamente com `@vercel/node`, roteando todas as requisições para ele — esse fluxo não passa pelo build/pasta `out` usado pelo Docker/`npm start`.
+
+## Log de requisições
+
+O middleware `requestLoggerMiddleware` registra cada requisição (data, método, url, status e duração) em um arquivo local `request.log`, ao final da resposta.


### PR DESCRIPTION
## Descrição

Adiciona a documentação base do repositório: `CLAUDE.md` (guia de arquitetura para o Claude Code), `README.md` reescrito em português, `CONTRIBUTING.md` com o padrão de branches/commits/PR, e o template de Pull Request do GitHub.

## Issue relacionada

Nenhuma issue relacionada — trabalho de documentação inicial.

## Tipo de alteração

- [ ] :bug: Fix
- [ ] :sparkles: Feat
- [ ] :ambulance: Hotfix
- [ ] :recycle: Refactor
- [ ] :test_tube: Test
- [ ] :zap: Perf
- [ ] :art: Style
- [x] :bulb: Docs
- [ ] :rocket: Build
- [ ] :see_no_evil: Chore
- [ ] :rewind: Revert

## Checklist

- [ ] Reviewers atribuídos
- [ ] Assignees atribuídos
- [x] Labels atribuídas
- [x] `npm run lint` e `npm run build` passam localmente

## Como testar

Abrir cada arquivo novo/alterado e revisar o conteúdo:
- `CLAUDE.md`
- `README.md`
- `CONTRIBUTING.md`
- `.github/PULL_REQUEST_TEMPLATE.md`
