### PR TITLE
Fix :bug: [#32] Restringe deploy do Vercel apenas a main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Para adicionar um novo recurso, copie o trio controller/route/service `__test__`
 
 - O `.env` é carregado via `dotenv` em `src/app.ts`; existe um `.env.example` como template. O `src/index.ts` atualmente fixa a porta em `3000` em vez de lê-la do ambiente.
 - O `vercel.json` builda `src/index.ts` diretamente com `@vercel/node` e roteia todos os caminhos para ele — isso ignora o build `npm run build`/pasta `out` usado pelo Docker/`npm start`.
+- `vercel.json` restringe deploy automático à branch `main` via `git.deploymentEnabled` (`"main": true, "*": false`) — push em outras branches não dispara preview deployment.
 - O `Dockerfile` é um build em dois estágios: compila com `tsc` em um estágio builder, depois copia `out/` e `.env` para um estágio de produção mais leve. Se um projeto não tiver `.env`, remova a linha `COPY .env ./` (observação já indicada inline no Dockerfile).
 
 ## Tooling de IA (skills, agents e spec-driven)

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
     "version": 2,
+    "git": {
+        "deploymentEnabled": {
+            "main": true,
+            "*": false
+        }
+    },
     "builds": [
         {
             "src": "src/index.ts",


### PR DESCRIPTION
## Descrição

O Vercel estava disparando deploy (preview deployment) para toda branch com push, não apenas para a `main`. `vercel.json` não tinha nenhuma configuração de `git.deploymentEnabled`, então nenhuma branch era excluída.

Adicionada a chave `git.deploymentEnabled` em `vercel.json`, restringindo deploy automático apenas à branch `main`. Documentado também em `CLAUDE.md`.

(Recriação do PR #33 — a branch foi renomeada de `enhancement/32-...` para `fix/32-...` para seguir o padrão de `CONTRIBUTING.md`, o que fechou o PR anterior automaticamente ao remover a branch antiga.)

## Issue relacionada

Closes #32

## Tipo de alteração

- [x] :bug: Fix

## Checklist

- [x] Reviewers atribuídos
- [x] Assignees atribuídos
- [x] Labels atribuídas
- [x] `npm run lint` e `npm run build` passam localmente

## Como testar

1. Dar push nesta branch (não `main`) e confirmar no dashboard do Vercel que nenhum deployment é disparado.
2. Após merge na `main`, confirmar que o deploy de produção continua funcionando normalmente.