### PR TITLE
Docs :bulb: Documenta padrão de branches/commits/PRs no CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ Para adicionar um novo recurso, copie o trio controller/route/service `__test__`
 - O `vercel.json` builda `src/index.ts` diretamente com `@vercel/node` e roteia todos os caminhos para ele — isso ignora o build `npm run build`/pasta `out` usado pelo Docker/`npm start`.
 - O `Dockerfile` é um build em dois estágios: compila com `tsc` em um estágio builder, depois copia `out/` e `.env` para um estágio de produção mais leve. Se um projeto não tiver `.env`, remova a linha `COPY .env ./` (observação já indicada inline no Dockerfile).
 
+## Padrão de branches, commits e PRs
+
+Toda branch, commit e PR deste repositório segue o padrão definido em `CONTRIBUTING.md`: branches como `<tipo>/<número-da-issue>-<descrição-curta>` (ex.: `fix/17-request-logger-appendfile`) e commits como `<Tipo> <ícone> [#<número-da-issue>] <descrição>` (ex.: `Fix :bug: [#17] ...`), usando um dos tipos da tabela de `CONTRIBUTING.md` (Fix, Feat, Hotfix, Refactor, Test, Perf, Style, Docs, Build, Chore, Revert) — não use labels do GitHub (ex.: `enhancement`) como `<tipo>` da branch/commit. A descrição do PR segue a estrutura de `.github/PULL_REQUEST_TEMPLATE.md` (Descrição, Issue relacionada, Tipo de alteração, Checklist, Como testar), não um corpo livre.
+
 ## Tooling de IA (skills, agents e spec-driven)
 
 - `.claude/skills/` — pacotes de conhecimento carregáveis a pedido (`express-resource-scaffold`, `express-request-logging`), complementando este arquivo com o passo a passo detalhado de cada convenção.


### PR DESCRIPTION
## Descrição

`CLAUDE.md` não referenciava o padrão de branches/commits/PRs já definido em `CONTRIBUTING.md`, então o fluxo de agents/execução podia acabar usando labels do GitHub (ex.: `enhancement`) como tipo de branch/commit em vez dos tipos padronizados (Fix, Feat, Hotfix, etc.).

Adicionada uma seção em `CLAUDE.md` referenciando `CONTRIBUTING.md` para o padrão de branches (`<tipo>/<número-da-issue>-<descrição>`), commits (`<Tipo> <ícone> [#<número>] <descrição>`) e PRs (descrição seguindo `.github/PULL_REQUEST_TEMPLATE.md`).

## Issue relacionada

Nenhuma issue relacionada.

## Tipo de alteração

- [x] :bulb: Docs

## Checklist

- [x] Reviewers atribuídos
- [x] Assignees atribuídos
- [x] Labels atribuídas
- [x] `npm run lint` e `npm run build` passam localmente

## Como testar

Leitura de `CLAUDE.md` — confirmar que a nova seção reflete corretamente o conteúdo de `CONTRIBUTING.md`.