### PR TITLE
Fix :bug: [#10] tsconfig.json sem include/exclude compila arquivos fora de src/

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node out/src/index.js",
+    "start": "node out/index.js",
     "prestart": "npm run build",
     "build": "tsc -p tsconfig.json --outDir out",
     "dev": "nodemon --watch src --ext ts --exec \"ts-node src/index.ts\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -104,5 +104,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Descrição

`tsconfig.json` não definia `rootDir`/`include`, então a saída do `tsc` era não-determinística: dependia de quais arquivos `.ts`/`.mts` existiam no diretório no momento do build.

- Localmente, `eslint.config.mts` na raiz do projeto fazia o `tsc` inferir o root de compilação como a raiz do projeto, emitindo `out/src/index.js`.
- No Docker (builder stage só copia `src/`), o `tsc` inferia o root como `src/`, emitindo `out/index.js` (flat).

Correção: `tsconfig.json` agora fixa `"rootDir": "./src"` e `"include": ["src/**/*.ts"]`, tornando a saída sempre flat (`out/index.js`) independente do ambiente. O script `start` do `package.json` foi atualizado de `node out/src/index.js` para `node out/index.js`. O `Dockerfile` não precisou de nenhuma alteração — seu `CMD` já usava `out/index.js`.

Validado localmente (`npm run build`, `npm start`) e via Docker (`npm run create-image` + `npm run create-container`, container subiu saudável, sem `Cannot find module`).

**Relacionado à #11** ("Dockerfile: CMD aponta para caminho errado do entrypoint"): o sintoma relatado ali só existia por causa dessa não-determinismo do build. Investigação anterior (com `docker build --no-cache`/`docker run`) confirmou que o `CMD` do Dockerfile já estava correto e que a correção sugerida na #11 (`out/src/index.js`) quebraria o container. Com esta correção, o caminho fica consistente em todos os ambientes, então o cenário da #11 deixa de ser reproduzível — mas não estou fechando a #11 automaticamente, para o autor confirmar antes.

## Issue relacionada

Closes #10

## Tipo de alteração

- [x] :bug: Fix

## Checklist

- [x] Reviewers atribuídos
- [x] Assignees atribuídos
- [x] Labels atribuídas
- [x] `npm run lint` e `npm run build` passam localmente

## Como testar

1. `rm -rf out && npm run build` — confirmar que `out/index.js` existe e `out/src/` não existe.
2. `npm start` — servidor inicia sem `Cannot find module`.
3. `npm run create-image && npm run create-container` — `docker ps` mostra o container `Up`, sem crash.