### PR TITLE
Fix :bug: [#37] Corrige deploymentEnabled do Vercel para usar globstar em branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
     "git": {
         "deploymentEnabled": {
             "main": true,
-            "*": false
+            "**": false
         }
     },
     "builds": [


### PR DESCRIPTION
## Descrição

`vercel.json` tinha `git.deploymentEnabled: { "main": true, "*": false }` (adicionado no PR #34 para a issue #32), mas o Vercel continuava gerando preview deployment em branches diferentes de `main` (confirmado nos PRs #34 e #36).

Causa raiz, confirmada na [documentação oficial da Vercel](https://vercel.com/docs/project-configuration/git-configuration#git.deploymentenabled): o matching de `deploymentEnabled` usa sintaxe minimatch, e um `*` simples **não cruza `/`** — só casa dentro de um único segmento de path. Como toda branch deste repositório segue o padrão `<tipo>/<slug>` (contém `/`), o padrão `"*"` nunca casava com nenhuma delas. A documentação também confirma: "By default, any unspecified branch is set to `true`" — então essas branches caíam no default (deploy habilitado), mesmo com a config presente.

Correção: trocar `"*"` por `"**"` (globstar, que cruza `/`), resultando em:
```json
{
  "git": {
    "deploymentEnabled": {
      "main": true,
      "**": false
    }
  }
}
```
Como uma branch que casa múltiplas regras é deployada se ao menos uma delas for `true` (também confirmado na doc), `main` continua casando com `"main": true` e sendo deployada normalmente.

## Issue relacionada

Closes #37

## Tipo de alteração

- [x] :bug: Fix

## Checklist

- [x] Reviewers atribuídos
- [x] Assignees atribuídos
- [x] Labels atribuídas
- [x] `npm run lint` e `npm run build` passam localmente

## Como testar

A validação real desta correção depende de observação humana neste próprio PR: como esta branch (`fix/37-vercel-deploymentenabled-globstar`) tem `/` no nome e já contém a correção, o bot do Vercel **não deve** comentar com um preview deployment (`Ready`) aqui — diferente do que aconteceu nos PRs #34 e #36. Se um comentário do bot aparecer mesmo assim, a causa raiz precisa ser reinvestigada (ex.: configuração manual no dashboard, ver spec em `.specs/bugs/vercel-preview-deploy-non-main/`).

Depois do merge, confirmar que o deploy de produção via `main` continua sendo acionado normalmente.