### PR TITLE
Fix :bug: [#39] Usa npm ci no Dockerfile para respeitar o lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /app
 
 COPY package.json package-lock.json tsconfig.json ./
 
-COPY src ./src
-
 RUN npm ci
+
+COPY src ./src
 
 RUN npm run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-COPY package.json tsconfig.json ./
+COPY package.json package-lock.json tsconfig.json ./
 
 COPY src ./src
 
-RUN npm install
+RUN npm ci
 
 RUN npm run build
 
@@ -16,12 +16,12 @@ WORKDIR /app
 
 COPY --from=builder /app/out ./out
 
-COPY package.json ./
+COPY package.json package-lock.json ./
 
 # Remover caso não tenha o .env
 COPY .env ./
 
-RUN npm install --omit=dev
+RUN npm ci --omit=dev
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Descrição

O `Dockerfile` (estágios `builder` e `production`) rodava `npm install` sem copiar `package-lock.json` para a imagem, então o build da imagem Docker ignorava o lockfile e instalava, para cada dependência, a versão mais recente que satisfizesse o range semver do `package.json`.

Confirmado durante a validação da issue #11: o lockfile fixa `dotenv@17.2.3`, mas a imagem Docker (build `--no-cache`) instalava `dotenv@17.4.2` — versão diferente da validada localmente, cujo array de "tips" impresso no stdout contém strings suspeitas ("for agents [www.vestauth.com]"), não presentes na versão pinada. Independente da conclusão sobre essas strings (ver issue #39 para detalhes), o Dockerfile não deveria poder divergir do lockfile.

Correção: copiar `package-lock.json` para os dois estágios e trocar `npm install`/`npm install --omit=dev` por `npm ci`/`npm ci --omit=dev`.

Validado com `docker build --no-cache` + `docker run`: o container sobe normalmente e `node_modules/dotenv` instalado dentro da imagem agora é exatamente `17.2.3` (igual ao lockfile), sem as strings suspeitas nos logs.

## Issue relacionada

Closes #39

## Tipo de alteração

- [x] :bug: Fix

## Checklist

- [x] Reviewers atribuídos
- [x] Assignees atribuídos
- [x] Labels atribuídas
- [x] `npm run lint` e `npm run build` passam localmente

## Como testar

1. `npm run create-image` (sem cache) seguido de `npm run create-container`.
2. `docker exec container cat node_modules/dotenv/package.json` — confirmar versão `17.2.3`, igual ao `package-lock.json`.
3. Confirmar que o container sobe normalmente (`docker ps`, `docker logs container`).