### PR TITLE
Chore :see_no_evil: Refina templates de spec/tasks e paralelismo do executor

### DIFF
--- a/.claude/agents/executor.md
+++ b/.claude/agents/executor.md
@@ -1,13 +1,15 @@
 ---
 name: executor
 description: Agente de execução. Use para implementar as tarefas de um tasks.md já existente em .specs/, marcando cada item como concluído conforme avança.
-tools: Read, Edit, Write, Grep, Glob, Bash, TodoWrite
+tools: Read, Edit, Write, Grep, Glob, Bash, TodoWrite, Agent
 ---
 
 # Executor
 
 - Trabalhe a partir de uma pasta de spec já existente em `.specs/features/<slug>/` ou `.specs/bugs/<slug>/`. Se não houver `tasks.md`, pare e peça para o agente `sdd` criar um antes de implementar.
-- Implemente uma tarefa por vez, na ordem do `tasks.md`, marcando cada item como concluído (`- [x]`) assim que verificado.
+- Implemente as tarefas na ordem do `tasks.md`, respeitando a seção "Plano de execução" quando ela existir, e marcando cada item como concluído (`- [x]`) assim que verificado.
+- Tarefas marcadas com `[P]` no título e pertencentes à mesma fase são independentes entre si (não tocam no mesmo arquivo, uma não depende do resultado da outra). Nesse caso, dispare uma sub-agent por tarefa `[P]` usando a ferramenta `Agent` (subagent_type: `general-purpose`), todas no mesmo turno, e aguarde os resultados antes de seguir para a próxima fase. Repasse a cada sub-agent o contexto necessário (trecho relevante da spec, a tarefa exata do `tasks.md`, as convenções do `CLAUDE.md`) — ela não tem acesso à sua conversa. Tarefas sem `[P]`, ou quando não há certeza de que são realmente independentes, continue implementando você mesmo, uma por vez.
+- Depois que as sub-agents de uma fase paralela terminarem, revise o resultado antes de marcar as tarefas como concluídas — não confie apenas no resumo da sub-agent, confira o diff/arquivo alterado.
 - Siga o scaffold `__test__.*` como referência de padrão (Controller → Service → Route) e as convenções do `CLAUDE.md` deste repositório.
 - Depois de cada tarefa relevante, rode `npm run lint` e `npm run build` antes de marcar como concluída.
 - Não amplie o escopo além do que está no `tasks.md`. Se a spec e o código realmente implementável divergirem, pare e avise em vez de decidir por conta própria.

--- a/.specs/_template/spec.md
+++ b/.specs/_template/spec.md
@@ -1,8 +1,9 @@
 # Spec: <nome-da-feature-ou-bug>
 
-## Tipo
-
-Feature | Bug
+> **Tipo:** `feature` | `bug` <br />
+> **Status:** `rascunho` <!-- rascunho -> em-revisao -> aprovada -> em-andamento -> implementada --> <br />
+> **Issue:** `#<numero-da-issue>` <br />
+> **Criado em:** `DD-MM-AAAA`
 
 ## Problema
 
@@ -10,17 +11,52 @@ O que está errado, ou o que falta, e por que isso importa.
 
 ## Objetivo
 
-O que essa mudança deve alcançar.
+O que essa mudança deve alcançar. Seja específico e verificável.
 
 ## Fora de escopo
 
-O que deliberadamente não será feito aqui.
+O que deliberadamente não será feito aqui, para evitar ambiguidade durante a execução.
+
+## Histórias de usuário (opcional)
+
+> Use esta seção apenas quando a mudança tiver mais de um fluxo/cenário relevante.
+> Para bugs simples ou ajustes pontuais, pule direto para **Critérios de aceite**.
+
+### P1: <título da história> ⭐ MVP
+
+**Como** <papel/persona>, **quero** <capacidade> **para que** <benefício>.
+
+**Critérios de aceite:**
+
+1. QUANDO <evento> ENTÃO o sistema DEVE <comportamento>
+2. QUANDO <caso de borda> ENTÃO o sistema DEVE <tratamento adequado>
+
+**Teste independente:** como validar que esta história funciona isoladamente.
+
+### P2: <título da história>
+
+(Mesma estrutura de P1.)
+
+## Casos de borda (opcional)
+
+- QUANDO <condição limite> ENTÃO o sistema DEVE <comportamento>
+- QUANDO <cenário de erro> ENTÃO o sistema DEVE <tratamento adequado>
 
 ## Critérios de aceite
 
 - [ ] ...
 - [ ] ...
 
-## Notas / decisões
+## Estratégia de validação (opcional)
 
-Qualquer decisão de design relevante tomada durante o planejamento.
+- **Checagens automatizadas:** ...
+- **Checagens manuais:** ...
+- **Rollback / mitigação:** o que fazer se algo der errado após a implementação.
+
+## Questões em aberto (opcional)
+
+- <pergunta ou decisão pendente que precisa de resposta antes/durante a execução>
+
+## Notas / decisões (opcional)
+
+Qualquer decisão de design relevante tomada durante o planejamento, incluindo alternativas descartadas e o motivo.

--- a/.specs/_template/tasks.md
+++ b/.specs/_template/tasks.md
@@ -1,9 +1,41 @@
 # Tasks: <nome-da-feature-ou-bug>
 
-- [ ] T1 — descrição da tarefa
-  - Arquivo(s): `src/...`
-  - Feito quando: critério objetivo e verificável
+> Spec: `./spec.md`
 
-- [ ] T2 — descrição da tarefa
-  - Arquivo(s): `src/...`
-  - Feito quando: critério objetivo e verificável
+## Plano de execução (opcional)
+
+Use esta seção apenas quando houver várias tarefas com dependência entre si.
+Esboce as fases e marque com `[P]` as tarefas de uma mesma fase que são
+independentes entre si (não editam o mesmo arquivo, uma não depende do
+resultado da outra) — o `executor` pode disparar essas em paralelo, uma
+sub-agent por tarefa:
+
+```
+Fase 1 (sequencial)  →  Fase 2 (T2 [P] e T3 [P] em paralelo)  →  Fase 3
+      T1                        T2 [P]    T3 [P]                    T4
+```
+
+## Tarefas
+
+- [ ] T1 — <descrição objetiva da tarefa>
+  - **Arquivo(s):** `src/...`
+  - **Depende de:** nenhuma
+  - **Feito quando:** critério objetivo e verificável (ex.: comportamento X passa a ocorrer, comando Y não gera erro)
+
+- [ ] T2 [P] — <descrição objetiva da tarefa>
+  - **Arquivo(s):** `src/...`
+  - **Depende de:** T1 <!-- remova esta linha se não houver dependência -->
+  - **Feito quando:** critério objetivo e verificável
+
+<!-- `[P]` no título marca a tarefa como paralelizável com outras `[P]` da mesma fase (ver "Plano de execução"). Omita o marcador se a tarefa for sequencial. -->
+
+<!--
+Cada tarefa deve ser pequena o suficiente para o executor marcar como concluída
+sem ambiguidade. Como este projeto não tem suíte de testes automatizada, o
+"Feito quando" costuma ser: o build/lint passa, o comportamento foi validado
+manualmente, ou o arquivo/config está no estado esperado.
+
+TODO: quando houver um sistema de testes automatizado neste repositório (feature
+futura), adicionar aqui um campo "Testes" por tarefa (ex.: unit | integration |
+none) e exigir que o "Feito quando" referencie os testes que cobrem a mudança.
+-->


### PR DESCRIPTION
## Descrição

Os templates de spec/tasks em `.specs/_template/` misturavam inglês e português, tinham campos de um fluxo "spec-driven" mais genérico que não se aplica a este template Express pequeno (MCP tools, rastreabilidade de requisitos, tipos de teste — este repo não tem suíte de testes configurada). Refina os templates e habilita o agente `executor` a paralelizar tarefas independentes com sub-agents.

## Alterações

- `.specs/_template/spec.md`: traduzido para português, seções sem uso prático (Histórias de usuário, Casos de borda, Estratégia de validação, Questões em aberto, Notas/decisões) marcadas como opcionais.
- `.specs/_template/tasks.md`: traduzido, removidos campos que não se aplicam ao projeto (Tools MCP/Skill, Tests, Gate, Requirement Traceability), reintroduzido o marcador `[P]` para tarefas paralelizáveis, adicionado TODO para quando houver suíte de testes automatizada no repositório.
- `.claude/agents/executor.md`: adicionada a ferramenta `Agent` e instrução para disparar sub-agents em paralelo (uma por tarefa) quando o `tasks.md` marcar tarefas `[P]` na mesma fase, revisando o resultado antes de marcar como concluído.

## Decisões técnicas

Os campos removidos (MCP, tipos de teste, rastreabilidade) vieram de um template genérico que não refletia a realidade deste repositório — não há testes automatizados nem uso de MCP tools nas tarefas atuais. Preferi remover em vez de manter como opcional/placeholder, para não sinalizar suporte a algo inexistente; um TODO marca a exceção (testes) para quando isso mudar.

## Como testar

1. Abrir `.specs/_template/spec.md` e `.specs/_template/tasks.md` e confirmar que estão em português e organizados.
2. Ler `.claude/agents/executor.md` e confirmar que a instrução de paralelismo `[P]` está coerente com o marcador do `tasks.md`.

> Sem issue relacionada — refinamento de tooling interno de planejamento (`.specs/`, `.claude/agents/`).