### PR TITLE
Fix :bug: [#24] Corrige metadados do package.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "package-lock.json": false,
         "package.json": false,
         "tsconfig.json": false,
-        "LICENSE": true
+        "LICENSE": true,
+        "**/.gitkeep": true
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "template-typescript",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
@@ -1458,6 +1458,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "template-typescript",
   "version": "1.0.0",
-  "description": "",
+  "description": "Boilerplate de API REST com Express e TypeScript, seguindo o padrão Controller → Service → Route, com suporte a Docker e deploy na Vercel.",
   "main": "index.js",
   "scripts": {
     "start": "node out/index.js",
@@ -14,7 +14,7 @@
   },
   "keywords": [],
   "author": "@felipe-sant",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
## Descrição

O `package.json` estava com o campo `description` vazio e o campo `license` incorreto (`ISC`), apesar de o repositório ter um arquivo `LICENSE` MIT na raiz. Preenche a descrição do template e corrige a licença para refletir o `LICENSE` real, e regenera o `package-lock.json` para manter o metadado consistente.

## Alterações

- `package.json`: preenche `description` com um resumo do boilerplate (Express + TypeScript, padrão Controller → Service → Route) e corrige `license` de `ISC` para `MIT`.
- `package-lock.json`: regenerado (`rm` + `npm install`) para refletir `license: MIT` no lockfile.
- `.vscode/settings.json`: adiciona `**/.gitkeep` ao `files.exclude`, ocultando esses arquivos no explorer do VSCode.

## Decisões técnicas

A issue original dizia que o campo `license` não existia, mas na verificação ele existia com valor incorreto (`ISC`); o objetivo prático é o mesmo — alinhar com a licença MIT real do projeto. Detalhes em `.specs/bugs/package-json-metadata/spec.md`.

## Como testar

1. `cat package.json` e confirmar `description` preenchida e `"license": "MIT"`.
2. `node -e "require('./package.json')"` sem erros (JSON válido).
3. `npm run lint && npm run build` sem erros.

Closes #24