### PR TITLE
Fix :bug: [#12] Restringe CORS a allowlist configurável via CORS_ORIGIN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 # Porta em que o servidor Express escuta (padrão: 3000, se omitida)
 PORT=3000
+
+# Lista de origens permitidas para CORS, separadas por vírgula (sem espaços).
+# Se omitida, nenhuma origem é liberada.
+# CORS_ORIGIN=http://localhost:5173,https://app.exemplo.com

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,11 @@ dotenv.config()
 
 const app = express()
 
-app.use(cors())
+const allowedOrigins = (process.env.CORS_ORIGIN ?? "")
+  .split(",")
+  .filter((origin) => origin !== "")
+
+app.use(cors({ origin: allowedOrigins }))
 app.use(express.json())
 app.use(requestLoggerMiddleware)
 


### PR DESCRIPTION
## Descrição

Em `src/app.ts`, `app.use(cors())` era chamado sem nenhuma opção, liberando qualquer origem. Como este é um template copiado como base de outros projetos, esse comportamento tende a passar sem revisão para produção.

## Alterações

- `src/app.ts`: origem do CORS agora derivada de `CORS_ORIGIN` (lista separada por vírgula); sem a variável definida, nenhuma origem é liberada (fail-closed).
- `.env.example`: documenta `CORS_ORIGIN` com exemplo comentado, no mesmo estilo do comentário de `PORT`.

## Decisões técnicas

- Fallback de segurança: quando `CORS_ORIGIN` não estiver definida, nenhuma origem é liberada (em vez de cair para `*`), para não reproduzir o problema original por esquecimento de configuração.
- Fora de escopo: propagação de `CORS_ORIGIN` em `vercel.json`/`Dockerfile`/CI, testes automatizados (repo não possui suíte configurada) e outras opções de CORS além de `origin`.

## Como testar

1. Definir `CORS_ORIGIN=http://localhost:5173` no ambiente e rodar `npm run dev`.
2. Requisição com `Origin: http://localhost:5173` deve receber `Access-Control-Allow-Origin: http://localhost:5173`.
3. Requisição com uma origem fora da allowlist (ou sem `CORS_ORIGIN` definida) não deve receber o header `Access-Control-Allow-Origin`.

## Impactos e pontos de atenção

- Qualquer projeto/ambiente que dependia do CORS aberto precisará definir `CORS_ORIGIN` explicitamente após adotar esta mudança.

> Closes #12