### PR TITLE
Feat :sparkles: [#13] Adiciona helmet para headers básicos de segurança

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "helmet": "^8.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1580,6 +1581,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "helmet": "^8.3.0"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express'
 import cors from 'cors'
+import helmet from 'helmet'
 import requestLoggerMiddleware from './middleware/requestLogger.middleware'
 import testRoutes from './routes/__test__.routes'
 import dotenv from "dotenv"
@@ -12,6 +13,7 @@ const allowedOrigins = (process.env.CORS_ORIGIN ?? "")
   .split(",")
   .filter((origin) => origin !== "")
 
+app.use(helmet({ crossOriginResourcePolicy: { policy: "cross-origin" } }))
 app.use(cors({ origin: allowedOrigins }))
 app.use(express.json())
 app.use(requestLoggerMiddleware)


### PR DESCRIPTION
## Descrição

Nenhum middleware definia headers básicos de segurança HTTP (`X-Content-Type-Options`, `Content-Security-Policy`, etc.) e o Express expunha `X-Powered-By`, revelando a tecnologia do backend. Como este é um template copiado como base de outros projetos, essa ausência tende a ser replicada sem revisão.

## Alterações

- `package.json`/`package-lock.json`: adiciona `helmet` como dependência de produção.
- `src/app.ts`: registra `app.use(helmet({ crossOriginResourcePolicy: { policy: "cross-origin" } }))` como primeiro middleware, antes de `cors`, `express.json`, o request logger e as rotas.

## Decisões técnicas

- Configuração padrão do `helmet`, exceto `crossOriginResourcePolicy`: o default da lib é `"same-origin"`, o que faria o navegador bloquear respostas cross-origin *independentemente* do CORS — neutralizando na prática a allowlist configurável via `CORS_ORIGIN` (#12). Por isso foi ajustado para `"cross-origin"`, achado durante revisão (`reviewer`) antes do commit.
- CSP e demais diretivas ficam com o padrão da biblioteca, mantendo o template genérico — quem copiar e precisar de uma política mais permissiva/restritiva ajusta localmente.
- Fora de escopo: variáveis de ambiente novas, testes automatizados (repo sem suíte configurada), mudanças em `vercel.json`/`Dockerfile`.

## Como testar

1. Rodar `npm run dev` e fazer `curl -i http://localhost:3000/api/test`.
2. Confirmar presença de `X-Content-Type-Options: nosniff` e `Cross-Origin-Resource-Policy: cross-origin`.
3. Confirmar ausência do header `X-Powered-By`.
4. Confirmar que corpo e status da resposta permanecem inalterados.

## Impactos e pontos de atenção

- Se algum projeto derivado do template vier a servir HTML/Swagger UI/uploads com preview, o CSP padrão do `helmet` pode bloquear scripts/estilos/iframes até ser customizado — decisão consciente documentada na spec, não uma falha desta implementação.

> Closes #13