### PR TITLE
Feat :sparkles: [#23] Adiciona engines no package.json fixando versão do Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "keywords": [],
   "author": "@felipe-sant",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
## Descrição

`package.json` não declarava o campo `engines`, então não havia nenhuma sinalização de qual versão do Node é esperada ao rodar o projeto localmente. O `Dockerfile` já fixa `node:20-alpine` em dois estágios, mas isso só é respeitado dentro do container — `npm install`/`npm run dev` local com outra major do Node não avisava nada.

## Alterações

- `package.json`: adiciona `"engines": { "node": ">=20" }`, alinhado à major usada no `Dockerfile`.

## Decisões técnicas

- Mantida exatamente a sintaxe sugerida na issue (`>=20`, sem limite superior), coerente com a granularidade de major já usada no `Dockerfile` (`node:20-alpine`, não uma versão de patch/minor exata).
- Sem `engineStrict`/`.npmrc` com `engine-strict`: o padrão do npm moderno já emite warning (não bloqueia `npm install`) em incompatibilidade, suficiente para o objetivo de avisar o desenvolvedor.

## Como testar

1. `npm run build` e `npm run lint` continuam passando sem erros.
2. `npm run dev` sobe o servidor normalmente.
3. Inspecionar `package.json` e confirmar `"engines": { "node": ">=20" }` presente, próximo a `license`/`devDependencies`.

## Impactos e pontos de atenção

- Nenhum impacto em runtime da aplicação — é só metadata de configuração do projeto.

> Closes #23