### PR TITLE
Fix :bug: [#17] Troca leitura+regravação do request.log por append

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,16 @@ Para adicionar um novo recurso, copie o trio controller/route/service `__test__`
 
 Toda branch, commit e PR deste repositório segue o padrão definido em `CONTRIBUTING.md`: branches como `<tipo>/<número-da-issue>-<descrição-curta>` (ex.: `fix/17-request-logger-appendfile`) e commits como `<Tipo> <ícone> [#<número-da-issue>] <descrição>` (ex.: `Fix :bug: [#17] ...`), usando um dos tipos da tabela de `CONTRIBUTING.md` (Fix, Feat, Hotfix, Refactor, Test, Perf, Style, Docs, Build, Chore, Revert) — não use labels do GitHub (ex.: `enhancement`) como `<tipo>` da branch/commit. A descrição do PR segue a estrutura de `.github/PULL_REQUEST_TEMPLATE.md` (Descrição, Issue relacionada, Tipo de alteração, Checklist, Como testar), não um corpo livre.
 
+## Convenção de tipagem
+
+O `tsconfig.json` já habilita `strict: true` (o que inclui `noImplicitAny`), então o compilador já bloqueia `any` implícito em todo o projeto. Além disso:
+
+- Não introduza `any` explícito no código — se um tipo for difícil de expressar, prefira `unknown` com uma checagem, ou modele o tipo corretamente.
+- Tipos de retorno de funções assíncronas e handlers devem ser explícitos, não inferidos (ex.: `async function createLogger(log: RequestLogEntry): Promise<void>`, `function requestLoggerMiddleware(...): void`).
+- Prefira um type/interface nomeado (em `src/types/*.types.ts`) a um literal inline repetido em mais de um lugar (parâmetro de função e objeto montado no call site, por exemplo) — evita duplicação e facilita reuso por outros módulos.
+
+Exemplo já aplicado no repositório: `RequestLogEntry` (`src/types/requestLog.types.ts`) é usado tanto no parâmetro de `createLogger` quanto na variável `log` montada em `requestLoggerMiddleware` (`src/middleware/requestLogger.middleware.ts`), no lugar do literal inline que existia antes.
+
 ## Tooling de IA (skills, agents e spec-driven)
 
 - `.claude/skills/` — pacotes de conhecimento carregáveis a pedido (`express-resource-scaffold`, `express-request-logging`), complementando este arquivo com o passo a passo detalhado de cada convenção.

--- a/src/middleware/requestLogger.middleware.ts
+++ b/src/middleware/requestLogger.middleware.ts
@@ -1,21 +1,22 @@
 import { Request, Response, NextFunction } from "express";
 import { randomUUID } from "node:crypto";
 import appendFile from "../utils/appendFile";
+import { RequestLogEntry } from "../types/requestLog.types";
 
-async function createLogger(log: {date: string, method: string, url: string, status: number, duration: string, ip: string | undefined, userAgent: string | undefined, requestId: string}) {
+async function createLogger(log: RequestLogEntry): Promise<void> {
     const path = "request.log"
     const content = JSON.stringify(log) + "\n"
     appendFile(path, content)
 }
 
-function requestLoggerMiddleware(req: Request, res: Response, next: NextFunction) {
+function requestLoggerMiddleware(req: Request, res: Response, next: NextFunction): void {
     const start = Date.now();
     const requestId = randomUUID();
 
     res.on("finish", () => {
         const duration = Date.now() - start;
         const now = new Date()
-        const log = {
+        const log: RequestLogEntry = {
             date: now.toLocaleString("pt-br"),
             method: req.method,
             url: req.originalUrl,

--- a/src/middleware/requestLogger.middleware.ts
+++ b/src/middleware/requestLogger.middleware.ts
@@ -1,15 +1,16 @@
 import { Request, Response, NextFunction } from "express";
-import readFile from "../utils/readFile";
-import createFile from "../utils/createFile";
+import { randomUUID } from "node:crypto";
+import appendFile from "../utils/appendFile";
 
-async function createLogger(log: {date: string, method: string, url: string, status: number, duration: string}) {
+async function createLogger(log: {date: string, method: string, url: string, status: number, duration: string, ip: string | undefined, userAgent: string | undefined, requestId: string}) {
     const path = "request.log"
-    const content = readFile(path) + JSON.stringify(log) + "\n"
-    createFile(path, content)
+    const content = JSON.stringify(log) + "\n"
+    appendFile(path, content)
 }
 
 function requestLoggerMiddleware(req: Request, res: Response, next: NextFunction) {
     const start = Date.now();
+    const requestId = randomUUID();
 
     res.on("finish", () => {
         const duration = Date.now() - start;
@@ -19,7 +20,10 @@ function requestLoggerMiddleware(req: Request, res: Response, next: NextFunction
             method: req.method,
             url: req.originalUrl,
             status: res.statusCode,
-            duration: `${duration}ms`
+            duration: `${duration}ms`,
+            ip: req.ip,
+            userAgent: req.headers["user-agent"],
+            requestId
         }
         createLogger(log)
     });

--- a/src/types/requestLog.types.ts
+++ b/src/types/requestLog.types.ts
@@ -1,0 +1,10 @@
+export interface RequestLogEntry {
+    date: string;
+    method: string;
+    url: string;
+    status: number;
+    duration: string;
+    ip: string | undefined;
+    userAgent: string | undefined;
+    requestId: string;
+}

--- a/src/utils/appendFile.ts
+++ b/src/utils/appendFile.ts
@@ -1,0 +1,11 @@
+import { appendFile as appendFileFs } from "fs/promises";
+
+async function appendFile(path: string, content: string): Promise<void> {
+    try {
+        await appendFileFs(path, content, "utf-8")
+    } catch (error) {
+        console.error("Erro ao acrescentar conteúdo ao arquivo", error)
+    }
+}
+
+export default appendFile


### PR DESCRIPTION
## Descrição

Corrige o middleware de log de requisições, que lia e regravava o arquivo `request.log` inteiro a cada requisição (O(n) por requisição), e aproveita a mudança para enriquecer o log com `ip`, `userAgent` e `requestId`. Adicionalmente, aplica tipagem explícita nos arquivos tocados (sem `any` implícito/explícito), fechando também a issue #48 documentada a partir dessa correção.

## Alterações

- Cria `src/utils/appendFile.ts`, um helper que usa `fs/promises.appendFile` para acrescentar a nova linha ao `request.log` sem ler o arquivo inteiro.
- Atualiza `src/middleware/requestLogger.middleware.ts` para usar o novo helper em vez de `readFile`/`createFile`, eliminando a releitura do arquivo a cada requisição.
- Adiciona os campos `ip`, `userAgent` e `requestId` (gerado com `crypto.randomUUID()`) ao objeto de log.
- Cria `src/types/requestLog.types.ts` com a interface `RequestLogEntry`, usada no lugar do literal inline repetido.
- Tipa explicitamente os retornos de `createLogger` (`Promise<void>`) e `requestLoggerMiddleware` (`void`).
- Documenta a convenção de tipagem explícita em uma nova seção do `CLAUDE.md`.

## Decisões técnicas

- Optou-se por um helper dedicado (`appendFile.ts`) em vez de chamar `fs.promises.appendFile` direto no middleware, mantendo o padrão já usado por `createFile.ts`/`readFile.ts` (um helper por operação de I/O).
- `readFile.ts`/`createFile.ts` não foram removidos (ficam sem uso ativo), pois removê-los é um cleanup fora do escopo desta issue.
- O formato do arquivo de log continua NDJSON (um objeto JSON por linha, sem array externo), pois é o que viabiliza o append incremental.
- `tsconfig.json` não precisou de alteração — `strict: true` já garante `noImplicitAny`; o trabalho de tipagem foi só remover literais inline duplicados e explicitar retornos.

## Como testar

1. Remover (ou renomear) `request.log`, se existir localmente.
2. Rodar `npm run dev`.
3. Disparar algumas requisições HTTP (ex.: `curl http://localhost:3000/api/test`).
4. Confirmar que `request.log` é criado do zero e cada requisição acrescenta uma linha JSON com `date`, `method`, `url`, `status`, `duration`, `ip`, `userAgent` e `requestId`.
5. Disparar novas requisições sem apagar o arquivo e confirmar que as linhas antigas não são reescritas (apenas novas linhas são acrescentadas ao final).
6. Rodar `npm run lint` e `npm run build` e confirmar que passam sem erros.

## Impactos e pontos de atenção

- `src/utils/readFile.ts` e `src/utils/createFile.ts` ficam sem uso ativo neste fluxo (mantidos por serem genéricos e fora do escopo desta correção).

Closes #17
Closes #48